### PR TITLE
Fix target-pane specification for global pane ID.

### DIFF
--- a/pane.go
+++ b/pane.go
@@ -146,7 +146,7 @@ func (p *Pane) RunCommand(command string) error {
 	args := []string{
 		"send-keys",
 		"-t",
-		fmt.Sprintf("%s:%d.%d", p.SessionName, p.WindowId, p.ID),
+		fmt.Sprintf("%%%d", p.ID),
 		command,
 		"C-m",
 	}


### PR DESCRIPTION
The existing format would be correct for window & pane indices. However, `ListPanes` collects the globally unique pane_id. Fixes #4.